### PR TITLE
add/remove pyindi-deleted class on vector elements when delProperty i…

### DIFF
--- a/example_clients/gui/gui.py
+++ b/example_clients/gui/gui.py
@@ -8,7 +8,7 @@ WEBPORT = 5905 # The port for the web app
 INDIPORT = 7624 # The indiserver port
 INDIHOST = "localhost" # Where the indiserver is running
 DEVICES = ["*"] # All devices is called by an asterisk
-CURRENT_DIR = Path(__file__).parent # The current directory
+CURRENT_DIR = Path.cwd() # The current directory
 TEMPLATE = "gui.html"
 
 # Build handlers with path for rendering, each path should have a handler

--- a/pyindi/www/static/css/indi.css
+++ b/pyindi/www/static/css/indi.css
@@ -444,6 +444,7 @@ When floating child in parent, the parent ignores them.
 }
 
 .pyindi-deleted {
-	opacity: 0.25
+	opacity: 0.25;
+	pointer-events: none;
 
 }

--- a/pyindi/www/static/css/indi.css
+++ b/pyindi/www/static/css/indi.css
@@ -442,3 +442,8 @@ When floating child in parent, the parent ignores them.
 	font-weight: 900;
 	font-size: 1rem;
 }
+
+.pyindi-deleted {
+	opacity: 0.25
+
+}

--- a/pyindi/www/static/js/builder-indi.js
+++ b/pyindi/www/static/js/builder-indi.js
@@ -358,10 +358,7 @@
 				if (event.key === "Enter") {
 
 					event.preventDefault() // TODO Test if needed
-					if(utilities.parentVectorIsDeleted(event.target)) {
-						//Do nothing if vector received delProperty.
-						return;
-					}
+
 					let value = event.target.value;
 					setindi("Text", generateId.indiXml(indi), property.name, value);
 				}
@@ -436,10 +433,7 @@
 			wo.addEventListener("keyup", (event) => {
 				if (event.key === "Enter") {
 					// Test if ok
-					if(utilities.parentVectorIsDeleted(event.target))
-					{//Do nothing if vector received delProperty.
-						return;
-					}
+
 					let min = parseFloat(wo.getAttribute("data-min"));
 					let max = parseFloat(wo.getAttribute("data-max"));
 					let value = event.target.value;
@@ -500,10 +494,6 @@
 			
 			// Create event listeners for input button
 			input.addEventListener("change", (event) => {
-				if (utilities.parentVectorIsDeleted(event.target)){
-					//Do nothing if vector received a delProperty.
-					return;
-				}
 				let name = event.target.value
 				let value = event.target.checked ? "On" : "Off"
 				setindi("Switch", generateId.indiXml(indi), name, value);

--- a/pyindi/www/static/js/builder-indi.js
+++ b/pyindi/www/static/js/builder-indi.js
@@ -275,6 +275,14 @@
 				document.querySelector(group).appendChild(html);
 			}
 		}
+		else {
+			//If we get here and the item has been deleted previously
+			// we should undelete by removing the class. 
+			var vector = document.getElementById(vectorSelector);
+			vector.classList.remove("pyindi-deleted");
+		}
+		
+
 	
 		return;
 	},
@@ -348,7 +356,12 @@
 			// If "Enter" is pressed on writeonly area, send new text to indi
 			wo.addEventListener("keyup", (event) => {
 				if (event.key === "Enter") {
+
 					event.preventDefault() // TODO Test if needed
+					if(utilities.parentVectorIsDeleted(event.target)) {
+						//Do nothing if vector received delProperty.
+						return;
+					}
 					let value = event.target.value;
 					setindi("Text", generateId.indiXml(indi), property.name, value);
 				}
@@ -423,6 +436,10 @@
 			wo.addEventListener("keyup", (event) => {
 				if (event.key === "Enter") {
 					// Test if ok
+					if(utilities.parentVectorIsDeleted(event.target))
+					{//Do nothing if vector received delProperty.
+						return;
+					}
 					let min = parseFloat(wo.getAttribute("data-min"));
 					let max = parseFloat(wo.getAttribute("data-max"));
 					let value = event.target.value;
@@ -483,6 +500,10 @@
 			
 			// Create event listeners for input button
 			input.addEventListener("change", (event) => {
+				if (utilities.parentVectorIsDeleted(event.target)){
+					//Do nothing if vector received a delProperty.
+					return;
+				}
 				let name = event.target.value
 				let value = event.target.checked ? "On" : "Off"
 				setindi("Switch", generateId.indiXml(indi), name, value);

--- a/pyindi/www/static/js/constants.js
+++ b/pyindi/www/static/js/constants.js
@@ -84,6 +84,15 @@ const ApprovedTypes = [
   "Light",
   "BLOB"
 ]
+
+/** 
+ * pyINDI approved xml tags.
+ * @enum {String}
+ * 
+*/
+const ApprovedTags = [
+	"delProperty"
+]
 /**
  * XML Parsing configuration
  * @enum {Regex}
@@ -91,6 +100,7 @@ const ApprovedTypes = [
 const XmlRegex = {
   XML_START: /<.e[twf]\S*Vector/, // Accept <set <new <def <get
   XML_MESSAGE: /<message\s+.*\/>.*/g, // Parse messages
+  XML_DELPROPERTY: /<delProperty\s.*\/>/g // Parse delProperty
 }
 /**
  * Default configuration for backup.

--- a/pyindi/www/static/js/maps-indi.js
+++ b/pyindi/www/static/js/maps-indi.js
@@ -429,7 +429,11 @@ const scrapeDeleteProperty = (partial_doc) => {
       var timestamp = root_node.getAttribute("timestamp");
 
       // Call the delete handler. 
-      updater.delete(device, name);
+      var indi = {};
+      indi.device = device;
+      indi.name = name;
+      indi.timestamp = timestamp;
+      updater.delete(indi);
 
       // Removes delProperty from xml.
       cp_partial_doc = cp_partial_doc.replace(match[0], "")   

--- a/pyindi/www/static/js/updater-indi.js
+++ b/pyindi/www/static/js/updater-indi.js
@@ -301,18 +301,8 @@
 	 * @param {String} name name of indi property.
 	 *
 	 */
-	delete(device, name) {
-		if(Config.CUSTOM_GUI) {
-		var deviceSelector = `[data-custom-device="${device}"]`;
-		var vectorSelector = `[data-custom-vector="${name}"]`;
-		}
-		else {
-
-			var deviceSelector = `[data-device="${device}"]`;
-			var vectorSelector = `[data-vector="${name}"]`;
-		}
-        delete(indi) {
-        var selector;
+	delete(indi) {
+		var selector;
         if (builder.customGui) {
           var deviceSelector = `[data-custom-device="${device}"]`;
  		  var vectorSelector = `[data-custom-vector="${name}"]`;
@@ -320,7 +310,7 @@
  		}
  		else {
  		  selector = `#${generateId.vector(indi)}`;
-
+		}
 
 		var ele = document.querySelector(`${selector}`);
 		if(ele)

--- a/pyindi/www/static/js/updater-indi.js
+++ b/pyindi/www/static/js/updater-indi.js
@@ -311,7 +311,15 @@
 			var deviceSelector = `[data-device="${device}"]`;
 			var vectorSelector = `[data-vector="${name}"]`;
 		}
-		var selector = `${deviceSelector}${vectorSelector}`; 
+        delete(indi) {
+        var selector;
+        if (builder.customGui) {
+          var deviceSelector = `[data-custom-device="${device}"]`;
+ 		  var vectorSelector = `[data-custom-vector="${name}"]`;
+ 		  selector = `${deviceSelector}${vectorSelector}`;
+ 		}
+ 		else {
+ 		  selector = `#${generateId.vector(indi)}`;
 
 
 		var ele = document.querySelector(`${selector}`);

--- a/pyindi/www/static/js/updater-indi.js
+++ b/pyindi/www/static/js/updater-indi.js
@@ -294,6 +294,29 @@
 		var vector = updater.vector(indi, appendTo);
 
 		return vector;
+	},
+	/**
+	 * Handles the delProperty tag. 
+	 * @param {String} device name of indi device.
+	 * @param {String} name name of indi property.
+	 *
+	 */
+	delete(device, name) {
+		if(Config.CUSTOM_GUI) {
+		var deviceSelector = `[data-custom-device="${device}"]`;
+		var vectorSelector = `[data-custom-vector="${name}"]`;
+		}
+		else {
+
+			var deviceSelector = `[data-device="${device}"]`;
+			var vectorSelector = `[data-vector="${name}"]`;
+		}
+		var selector = `${deviceSelector}${vectorSelector}`; 
+
+
+		var ele = document.querySelector(`${selector}`);
+		if(ele)
+			ele.classList.add('pyindi-deleted');
 	}
 };
 

--- a/pyindi/www/static/js/utils-indi.js
+++ b/pyindi/www/static/js/utils-indi.js
@@ -120,6 +120,18 @@ const utilities = {
 				outStr = numStr
 		}
 		return outStr;
+	},
+
+	/**
+	 * Given an input, returs the parent fieldset vector
+	 * @param {HTMLElement} ele The number to format.
+	 * @returns {HTMLElement} THe parent fieldset vector
+	 */
+	parentVectorIsDeleted(ele) {
+		while (!ele.classList.contains("pyindi-vector")) {
+			ele = ele.parentElement
+		}
+		return ele.classList.contains("pyindi-deleted")
 	}
 };
 


### PR DESCRIPTION
When a delproperty is received by maps-indi.js, it adds the pyindi-deleted class to the  vector element. Currently this sets the opacity to 0.25. Also the event listerners for all vector properties look to see if the vector is deleted before using the setindi function.  I tested this on the indilib CCD Simulator. Connecting and disconnecting deletes a series of properties. 