### PR TITLE
Updated the api on how to use pyindi and reduced amount of times scanning through xml

### DIFF
--- a/example_clients/gui/gui.html
+++ b/example_clients/gui/gui.html
@@ -4,7 +4,7 @@
 		{% raw pyindi_head %}
 		<title>{{ title }}</title>
 		<script>
-			/**
+				/**
 			* Runs on load. Builds the default properties using a callback.
 			*/
 			const main = () => {
@@ -26,7 +26,12 @@
         let htmlElement = handle(indi);
 
         // Bad selector, meaning the custom GUI selector not found
+        // Want to check if not delProperty, message, or BLOB before issuing tip
         if (!htmlElement) {
+          if (ApprovedOp.includes(indi.op) && indi.metainfo !== "bvp") {
+            tag_str = `<div data-custom-vector="${indi.name}" data-custom-device="${indi.device}"/>`;
+            console.debug(`Selector not found. To add vector to page use ${tag_str}`);
+          }
           return;
         }
 

--- a/example_clients/gui/gui.html
+++ b/example_clients/gui/gui.html
@@ -2,38 +2,46 @@
 <html lang="en">
 	<head>
 		{% raw pyindi_head %}
-		<title>GUI</title>
+		<title>{{ title }}</title>
 		<script>
 			/**
 			* Runs on load. Builds the default properties using a callback.
 			*/
 			const main = () => {
 				var devices = {% raw json_encode(devices) %};
-				initialize(devices);
+				initialize(devices, customGui=true);
 				return;
 			}
 
 			/**
-			* This function will be called whenever an INDI property with the device 
+			* This function will be called whenever an INDI property with the device
 			*	{{ devices }} is received. This is where users should modify the
 			*	code to append to specific objects.
 			*
-			*	If wanting to use a custom GUI, enable in the configuration and provide the correct syntax for selecting 
+			*	If wanting to use a custom GUI, enable in the configuration and provide the correct syntax for selecting
 			* elements.
 			* @param {Object} indi Contains all information about INDI property
 			*/
 			const handleProperty = (indi) => {
-        // If definition property, build it
-				if (indi.op === IndiOp.DEFINITION) {
-          var vector = updater.custom(indi);
-          // If returned vector is null, then bad selector in the <body> or not found
-          if (!vector) {
-            return;
-          }
-          // Handle vector for the first time here
-				}
-				// Handle vector every time it comes in
-				var vector = updater.vector(indi);
+        let htmlElement = handle(indi);
+
+        // Bad selector, meaning the custom GUI selector not found
+        if (!htmlElement) {
+          return;
+        }
+
+        if (indi.op === IndiOp.DEFINITION) {
+          // Only update once (on definition)
+          // Use for adding tooltips or modifying the look once
+        }
+        else if (indi.op === IndiOp.SET) {
+          // Update everytime new values come in
+          // Use for updating labels with values
+        }
+        else {
+          console.warn(`Indi definition: ${indi.op} not found`)
+        }
+
         return;
 			}
 		</script>

--- a/example_clients/gui/gui.py
+++ b/example_clients/gui/gui.py
@@ -1,37 +1,39 @@
 #!/usr/bin/python3.8
 from pathlib import Path
-from tornado.web import StaticFileHandler
+# from tornado. import StaticFileHandler
 from pyindi.webclient import INDIWebApp, INDIHandler
 
 # Configuration
-WEBPORT = 5905 # The port for the web app
-INDIPORT = 7624 # The indiserver port
-INDIHOST = "localhost" # Where the indiserver is running
-DEVICES = ["*"] # All devices is called by an asterisk
-CURRENT_DIR = Path(__file__).parent # The current directory
+WEBPORT = 5905  # The port for the web app
+INDIPORT = 7624  # The indiserver port
+INDIHOST = "localhost"  # Where the indiserver is running
+DEVICES = ["*"]  # All devices is called by an asterisk
+CURRENT_DIR = Path(__file__).parent  # The current directory
 TEMPLATE = "gui.html"
+
 
 # Build handlers with path for rendering, each path should have a handler
 class GUI(INDIHandler):
     def get(self):
         # Pass additional variables to appear in the html template
-        self.indi_render(CURRENT_DIR / TEMPLATE, devices=DEVICES, 
-                         example_variable="Hello World")
+        self.indi_render(CURRENT_DIR / TEMPLATE, devices=DEVICES,
+                         example_variable="Hello World", title="Test GUI")
+
 
 web_app = INDIWebApp(webport=WEBPORT, indihost=INDIHOST, indiport=INDIPORT)
 # If storing images, create image directory
-# imgs = Path("./imgs")
+# imgs = Path("/tmp/imgs")
 # imgs.mkdir(exist_ok=True)
 
 print(f"Go to http://<server_name>:{WEBPORT}")
-print(f"If the server is on localhost go to:")
+print("If the server is on localhost go to:")
 print(f"http://localhost:{WEBPORT}/")
 
 # Attach handlers and build the application
 # For images, use tornado.web.StaticFileHandler and link the path
 web_app.build_app(
     [
-        (r"/", GUI)
+        (r"/", GUI),
         # (r"/imgs/(.*)", StaticFileHandler, {"path": imgs})
     ],
 )

--- a/pyindi/www/static/css/indi.css
+++ b/pyindi/www/static/css/indi.css
@@ -59,7 +59,7 @@
 	--invalid: #FF5252;
 	--invalid-focus: #FF8A80;
 	--indistate-unknown: magenta;
-	--primary-light: #B388FF; 
+	--primary-light: #B388FF;
 	--primary: #7C4DFF;
 	--primary-dark: #651FFF;
 	--text-header-h1: #fff;
@@ -88,7 +88,6 @@
 	--bg-light: #616161;
 	--bg-icon: #fff;
 	--bg-switch-press: #424242;
-	
 }
 .text-right {
 	text-align: right;
@@ -324,17 +323,17 @@ body {
 	box-shadow: 0 0 0 0.125rem var(--invalid-focus);
 }
 
-/* 
+/*
 https://stackoverflow.com/questions/12540436/height-of-parent-div-is-zero-even-if-it-has-child-with-finite-heights
 When floating child in parent, the parent ignores them.
 */
 .fix-div:after {
-	content: " "; 
+	content: " ";
 	display: block;
 	clear: both;
 }
 .pyindi-number-div:after {
-	content: " "; 
+	content: " ";
 	display: block;
 	clear: both;
 }
@@ -410,7 +409,7 @@ When floating child in parent, the parent ignores them.
 }
 .pyindi-tooltip:after {
 	border-right: 6px solid transparent;
-	border-bottom: 6px solid var(--bg-nav); 
+	border-bottom: 6px solid var(--bg-nav);
   border-left: 6px solid transparent;
   content: '';
   height: 0;

--- a/pyindi/www/static/js/builder-indi.js
+++ b/pyindi/www/static/js/builder-indi.js
@@ -64,7 +64,7 @@
 		div.setAttribute("data-title", tip);
 		// Fontawesome classes and icon
 		i.classList.add("fas", "fa-question-circle", "icon-tooltip");
-		
+
 		div.appendChild(i);
 		legend.appendChild(div);
 
@@ -167,7 +167,7 @@
 			let group = document.querySelector(`div.pyindi-group[data-group="${indi.group}"][data-device="${indi.device}"]`);
 			utilities.hideSibling(group);
 		})
-		
+
 		// Build label for device
 		var p = document.createElement("p");
 
@@ -193,21 +193,21 @@
 		div.setAttribute("data-group", indi.group);
 		div.id = generateId.group(indi);
 		var parent = document.querySelector(`#${generateId.device(indi)}`);
-	
+
 		div.classList.add("pyindi-group");
 		// If custom GUI don't do this but device has hidden class added for new groups
 		if (!this.customGui && parent.classList.contains("hidden")) {
 			div.classList.add("hide");
 		}
-	
+
 		// Build header group
 		var header = document.createElement("div");
 		header.classList.add("pyindi-group-header");
-	
+
 		// Build icon for min/max
 		var i = document.createElement("i");
 		i.classList.add("fas", "fa-minus-circle", "minmax"); // fontawesome
-	
+
 		// Handle the minimize and maximize button click
 		i.addEventListener("click", (event) => {
 			if (event.target.classList.contains("fa-minus-circle")) {
@@ -218,23 +218,23 @@
 				event.target.classList.add("fa-minus-circle");
 				event.target.classList.remove("fa-plus-circle");
 			}
-			
+
 			// Get first child then hide all children in group
 			let vector = document.querySelector(`fieldset[data-group="${indi.group}"][data-device="${indi.device}"]`);
 			utilities.hideSibling(vector);
-	
+
 		})
-		
+
 		// Build the title for group
 		var p = document.createElement("p");
 		p.textContent = indi.group;
 		p.classList.add("pyindi-h2");
-	
+
 		// Append all
 		header.appendChild(i);
 		header.appendChild(p);
 		div.appendChild(header);
-	
+
 		return div;
 	},
 
@@ -248,7 +248,7 @@
 		if (!document.getElementById(vectorSelector)) {
 			console.debug(`Creating new ${indi.metainfo}=${generateId.vector(indi)}`);
 			var html = this.vector(indi);
-	
+
 			switch (indi.metainfo) {
 				case "nvp":
 					html = this.numbers(indi, html);
@@ -265,7 +265,7 @@
 				default:
 					console.warn(`indi metainfo=${indi.metainfo} not recognized!`)
 			}
-	
+
 			// Append to designated spot unless null then append to group
 			if (appendTo) {
 				appendTo.appendChild(html);
@@ -275,7 +275,7 @@
 				document.querySelector(group).appendChild(html);
 			}
 		}
-	
+
 		return;
 	},
 
@@ -292,22 +292,22 @@
 		fieldset.setAttribute("data-device", indi.device);
 		fieldset.setAttribute("data-group", indi.group);
 		fieldset.setAttribute("data-vector", indi.name);
-	
+
 		// Create legend for fieldset
 		var legend = document.createElement("legend");
-	
+
 		// Create span led in legend for indistate
 		var led = document.createElement("span");
 		led.classList.add("led");
-	
+
 		// Create text node for legend to not overwrite the led span
 		var text = document.createTextNode(indi.label);
-	
+
 		// Build fieldset by appending all
 		legend.appendChild(led);
 		legend.appendChild(text);
 		fieldset.appendChild(legend);
-	
+
 		return fieldset;
 	},
 
@@ -321,30 +321,30 @@
 		indi.values.forEach((property) => {
 			// Create div that the indi text row will exist
 			var div = document.createElement("div");
-			
+
 			var id = generateId.property(indi, property);
 			div.id = id;
 			div.classList.add("fix-div", "pyindi-row");
-	
+
 			// Create label for indi text row
 			var label = document.createElement("label");
 			label.textContent = property.label;
 			label.classList.add("pyindi-property-label", "pyindi-col");
 			label.htmlFor = `${id}__input`;
-	
+
 			div.appendChild(label);
-	
+
 			// Build ro and wo
 			var ro = document.createElement("label");
-	
+
 			ro.readOnly = true;
 			ro.classList.add("pyindi-property", "pyindi-ro", "pyindi-col");
 			ro.textContent = property.value;
-	
+
 			var wo = document.createElement("input");
 			wo.classList.add("pyindi-property", "pyindi-wo", "pyindi-col");
 			wo.id = `${id}__input`;
-	
+
 			// If "Enter" is pressed on writeonly area, send new text to indi
 			wo.addEventListener("keyup", (event) => {
 				if (event.key === "Enter") {
@@ -353,13 +353,13 @@
 					setindi("Text", generateId.indiXml(indi), property.name, value);
 				}
 			});
-	
+
 			// Determine if it is readonly, writeonly, or both and append
 			div = this.readWrite(indi.perm, div, ro, wo);
-	
+
 			// Append the div to the fieldset
 			appendTo.appendChild(div);
-	
+
 		});
 		return appendTo;
 	},
@@ -374,31 +374,31 @@
 		indi.values.forEach((property) => {
 			// Create div that the indi labal, ro, and wo will exist in
 			var div = document.createElement("div");
-	
+
 			var id = generateId.property(indi, property);
 			div.id = id;
 			div.setAttribute("data-format", property.format);
-	
+
 			div.classList.add("fix-div", "pyindi-row");
-	
+
 			// Create label for indi text row
 			var label = document.createElement("label");
 			label.textContent = property.label;
 			label.classList.add("pyindi-property-label", "pyindi-col");
 			label.htmlFor = `${id}__input`;
-	
+
 			div.appendChild(label);
-	
+
 			// Build ro and wo
 			var ro = document.createElement("label"); // Make textarea for no resize
 			ro.textContent = property.value;
 			ro.classList.add("pyindi-property", "pyindi-ro", "pyindi-col");
-	
+
 			var wo = document.createElement("input");
 			wo.classList.add("pyindi-property", "pyindi-wo", "pyindi-col")
 			wo.id = `${id}__input`;
 			wo.defaultValue = 0;
-	
+
 			// Add min and max data attributes
 			var tipStr = '';
 			if (property.hasOwnProperty("min")) {
@@ -409,13 +409,13 @@
 				wo.setAttribute("data-max", property.max);
 				tipStr += `Maximum value = ${property.max} `;
 			}
-	
+
 			// Display invalid for numbers out of range
 			var tip = document.createElement("div");
 			tip.textContent = tipStr;
 			tip.id = `${id}__tip`;
 			tip.classList.add("hide", "text-right", "tip");
-	
+
 			wo.addEventListener("blur", (event) => {
 				wo.value.length == 0 ? wo.value = 0 : ""; // Fill in 0 if empty
 			})
@@ -438,15 +438,15 @@
 					}
 				}
 			});
-	
+
 			// Determine if it is readonly, writeonly, or both and append
 			div = this.readWrite(indi.perm, div, ro, wo);
-			
-	
+
+
 			// Append the tip to div and div to the fieldset
 			div.appendChild(tip);
 			appendTo.appendChild(div);
-	
+
 		});
 		return appendTo;
 	},
@@ -463,37 +463,37 @@
 		indi.values.forEach((property) => {
 			var span = document.createElement("span");
 			var id = generateId.property(indi, property);
-	
+
 			// Create label for button text
 			var label = document.createElement("label")
 			label.classList.add("pyindi-switch-label");
 			label.htmlFor = id;
 			label.textContent = property.label
-	
+
 			// Create button
 			var input = document.createElement("input");
 			input.type = type;
 			input.id = id;
 			input.name = utilities.noSpecialCharacters(indi.name);
-	
+
 			input.classList.add("pyindi-switch-input");
 			input.value = utilities.noSpecialCharacters(property.name);
-	
+
 			input.checked = property.value === "On" ? true : false;
-			
+
 			// Create event listeners for input button
 			input.addEventListener("change", (event) => {
 				let name = event.target.value
 				let value = event.target.checked ? "On" : "Off"
 				setindi("Switch", generateId.indiXml(indi), name, value);
 			})
-			
+
 			// Append all
 			span.appendChild(input);
 			span.appendChild(label);
 			appendTo.appendChild(span);
 		})
-	
+
 		return appendTo;
 	},
 
@@ -508,17 +508,17 @@
 			var span = document.createElement("span"); // To store each light in
 			var id = generateId.property(indi, property);
 			var label = document.createElement("label");
-	
+
 			label.classList.add("pyindi-light-label");
 			label.id = id;
 			label.textContent = property.label;
 			label.style.backgroundColor = converter.indiToCss(property.value);
-	
+
 			// Append all
 			span.appendChild(label)
 			appendTo.appendChild(span);
 		});
-	
+
 		return appendTo;
 	},
 
@@ -545,7 +545,7 @@
 				break;
 			default:
 		}
-	
+
 		return appendTo;
 	},
 };

--- a/pyindi/www/static/js/constants.js
+++ b/pyindi/www/static/js/constants.js
@@ -62,6 +62,8 @@ const IndiOp = {
 	SET: "set",
 	NEW: "new",
 	GET: "get",
+  DELETE: "del",
+  MESSAGE: "mes",
 }
 
 /* Constants */
@@ -71,7 +73,7 @@ const IndiOp = {
  */
 const ApprovedOp = [
   "set",
-  "def"
+  "def",
 ]
 /**
  * pyINDI approved properties.
@@ -85,22 +87,21 @@ const ApprovedTypes = [
   "BLOB"
 ]
 
-/** 
+/**
  * pyINDI approved xml tags.
  * @enum {String}
- * 
+ *
 */
 const ApprovedTags = [
-	"delProperty"
+	"delProperty",
+  "message"
 ]
 /**
  * XML Parsing configuration
  * @enum {Regex}
  */
 const XmlRegex = {
-  XML_START: /<.e[twf]\S*Vector/, // Accept <set <new <def <get
-  XML_MESSAGE: /<message\s+.*\/>.*/g, // Parse messages
-  XML_DELPROPERTY: /<delProperty\s.*\/>/g // Parse delProperty
+  XML_START: /<*\S*(Vector|delProperty|message)/, // Get groups and vectors
 }
 /**
  * Default configuration for backup.
@@ -112,7 +113,7 @@ const XmlRegex = {
   LOGGING_WELCOME_MESSAGE: "INDI messages & logs displayed below", // Message to display at start of log
   INDI_CONSOLE_DEBUG: false, // Prints INDI mesages to the console
   READONLY_PORT: 8081, // setindi() is muted when on this port
-  WS_PAGE: "/indi/websocket", // Websocket url 
+  WS_PAGE: "/indi/websocket", // Websocket url
   WS_SEND_WAIT: 30, // Millaseconds, how long to wait to resend
   WS_RETRY: 1000, // Millaseconds, how long to wait to reconnect
 }

--- a/pyindi/www/static/js/indi.js
+++ b/pyindi/www/static/js/indi.js
@@ -30,3 +30,38 @@ const initialize = (devices, customGui=true) => {
 	return;
 }
 
+/**
+ * Handles incoming indi objects depending on indi operation such as set,
+ * definition, etc.. Can determine to use custom gui or not. Check the return
+ * value to see if selector was valid.
+ * @param {Object} indi Contains all indi information of property
+ * @returns
+ */
+const handle = (indi) => {
+  var htmlElement;
+
+  if (indi.op === IndiOp.DEFINITION) {
+    // Handle a custom GUI
+    if (builder.customGui) {
+      htmlElement = updater.custom(indi);
+      // If couldn't locate custom GUI, exit
+      if (!htmlElement) {
+        return;
+      }
+    }
+    // Handle normally
+    else {
+      updater.handle(indi);
+    }
+    // During a definition, still need to update the vector values
+    htmlElement = updater.vector(indi);
+  }
+  // Only update values if set
+  else if (indi.op == IndiOp.SET) {
+    htmlElement = updater.vector(indi);
+  }
+  // TODO DELETE etc.
+
+  return htmlElement;
+}
+

--- a/pyindi/www/static/js/indi.js
+++ b/pyindi/www/static/js/indi.js
@@ -60,7 +60,19 @@ const handle = (indi) => {
   else if (indi.op == IndiOp.SET) {
     htmlElement = updater.vector(indi);
   }
-  // TODO DELETE etc.
+  // For delete and message, if we assign htmlElement, users will get element
+  else if (indi.op == IndiOp.DELETE) {
+    console.debug(`Deleting ${generateId.vector(indi)}`)
+    updater.delete(indi);
+  }
+  else if (indi.op == IndiOp.MESSAGE) {
+    var message = indi.message;
+    var timestamp = indi.timestamp;
+    var device = indi.device;
+
+    Config.INDI_CONSOLE_DEBUG && console.log(`${timestamp} ${device} ${message}`);
+    logging.log(message, timestamp, device);
+  }
 
   return htmlElement;
 }

--- a/pyindi/www/static/js/logger-indi.js
+++ b/pyindi/www/static/js/logger-indi.js
@@ -26,7 +26,7 @@
 			return;
 		}
 		// Build log message
-		var p = document.createElement("p");
+		let p = document.createElement("p");
 		p.classList.add("pyindi-log");
 		p.textContent = `${timestamp} ${device} ${message}`
 
@@ -36,8 +36,8 @@
     }
 
     // Calculate auto-scroll to new messages
-    var isScrolledToBottom = this.logger.scrollHeight - this.logger.clientHeight <= this.logger.scrollTop + 1;
-    var loggerHeight = this.logger.scrollHeight;
+    let isScrolledToBottom = this.logger.scrollHeight - this.logger.clientHeight <= this.logger.scrollTop + 1;
+    let loggerHeight = this.logger.scrollHeight;
 		// https://stackoverflow.com/questions/25505778/automatically-scroll-down-chat-div
 		this.logger.appendChild(p);
 		if (isScrolledToBottom) {

--- a/pyindi/www/static/js/maps-indi.js
+++ b/pyindi/www/static/js/maps-indi.js
@@ -15,23 +15,11 @@ document.addEventListener("DOMContentLoaded", () => {
       indi_types += `${op}${type}Vector`;
     })
   })
-
-  /** *
-  * This bit of code adds the delProperty tag to list of accpeted
-  * INDI types. Functionally this does nothing because I went with
-  * the scrapeDeleteProperties similar to how messages are handled
-  * The delProperty is scraped long before the indi_types are checked
-  * if this PR is approved we should delete this bit and the ApprovedTags
-  * array in the constants.js.
-  *
-  * Scott S. 6/1/2022
-  */
   ApprovedTags.forEach((tag) => {
     if (indi_types.length) {
         indi_types += ", "; // Append , and space if there already is part of str
       }
       indi_types += `${tag}`;
-
   })
   console.log(`Accepting ${indi_types}`);
 
@@ -239,7 +227,7 @@ const setPropertyCallback = (property, callback, init=false) => {
  * Flattens an INDI property's XML element into a javascript object. This
  * copies the flattenIndi function but uses a nesting approach (less
  * flattened). Note that step, min, max attributes and the value for Properties
- *  of type Number are converted to numeric type, all others are string type.
+ * of type Number are converted to numeric type, all others are string type.
  * Also, BLOBs are already unpacked from base64.
  * @param {XMLDocument} xml The parsed xml.
  * @returns {Object} Contains all information from INDI property.
@@ -254,12 +242,11 @@ function flattenIndiLess(xml) {
 
   var isnum = false;
   var isblob = false;
-
   if (xml.nodeName.includes("Number")) {
     isnum = true;
     indi.metainfo = "nvp";
   }
-  else if (xml.nodeName.includes("Blob")) {
+  else if (xml.nodeName.includes("BLOB")) {
     isblob = true;
     indi.metainfo = "bvp";
   }
@@ -285,8 +272,7 @@ function flattenIndiLess(xml) {
 	children = []
 	var i = 0;
   var child_nodes = xml.children;
-  for (var j=0; j<child_nodes.length; j++)
-  {
+  for (var j=0; j<child_nodes.length; j++) {
     var child = child_nodes[j];
     var name = child.getAttribute("name");
 
@@ -330,7 +316,6 @@ function flattenIndiLess(xml) {
     indi.values = children;
     i++;
   }
-
   return indi;
 }
 
@@ -347,32 +332,35 @@ const updateProperties = (xml_text) => {
   // Append next chunk
   partial_doc += xml_text;
 
-  // Process any/all complete INDI messages in partial_doc
   while (true) {
     // Find first opening tag, done if none
-    partial_doc = scrapeMessages(partial_doc);
-    partial_doc = scrapeDeleteProperty(partial_doc);
-
     var start_match = XmlRegex.XML_START.exec(partial_doc);
-
     if (!start_match || start_match.index < 0) {
       return;
     }
 
     // Find next matching closing tag, done if none
     // [0] is the matched string
-    var end_xml_str = `${start_match[0].replace("<", "</")}>`;
+    // [1] is the group string
+    var end_xml_str = "";
+    // Handle the approved tags which end in "/>"
+    if (ApprovedTags.includes(start_match[1])) {
+      end_xml_str = "/>";
+    }
+    // Handle *Vector tags, which end with </*Vector
+    else if (start_match[1] === "Vector") {
+      end_xml_str = `${start_match[0].replace("<", "</")}>`;
+    }
     var end_idx = partial_doc.indexOf(end_xml_str, start_match.index);
     if (end_idx < 0) {
+      // No end index, finished...
       return;
     }
     var end_after_idx = end_idx+end_xml_str.length;
 
     // Extract property xml and remove from partial_doc
     var xml_doc = partial_doc.substring(start_match.index, end_after_idx);
-
     partial_doc = partial_doc.substring(end_after_idx);
-
     try {
       const parser = new DOMParser();
       var dom = parser.parseFromString(xml_doc, "application/xml");
@@ -383,8 +371,8 @@ const updateProperties = (xml_text) => {
       var root_name = root_node.nodeName; // Root name
       var device = root_node.getAttribute("device");
       var name = root_node.getAttribute("name");
-      // Check if root name is in list of indi_types
 
+      // Check if root name is in list of indi_types
       if (!indi_types.split(', ').includes(root_name)) {
         console.warn(`Bad type: ${root_name}`);
         return;
@@ -393,7 +381,6 @@ const updateProperties = (xml_text) => {
       // Gets function from handleProperty callback in client.html
       // If property doesn't exist specified then use general
       var callback = setPropertyCallbacks[`${device}.${name}`] || setPropertyCallbacks[`${device}.*`] || setPropertyCallbacks['*.*'];
-
       if (callback) {
         var indi = flattenIndiLess(root_node);
         callback(indi);
@@ -404,79 +391,5 @@ const updateProperties = (xml_text) => {
       return;
     }
   }
-
   return;
-}
-
-/**
- * Function that scrapes the incoming xml for delProperty tags
- * debugging is enabled.
- * @param {XMLDocument} partial_doc XML text from INDI.
- * @returns {XMLDocument} Copy of the partial document put in.
- */
-const scrapeDeleteProperty = (partial_doc) => {
-  try {
-     var cp_partial_doc = partial_doc;
-
-    while ((match = XmlRegex.XML_DELPROPERTY.exec(partial_doc))) {
-      // Parse match
-      const parser = new DOMParser();
-      var dom = parser.parseFromString(match, "application/xml");
-      var root_node = dom.documentElement; // Root node
-
-
-      var device = root_node.getAttribute("device");
-      var name = root_node.getAttribute("name");
-      var timestamp = root_node.getAttribute("timestamp");
-
-      // Call the delete handler.
-      var indi = {};
-      indi.device = device;
-      indi.name = name;
-      indi.timestamp = timestamp;
-      updater.delete(indi);
-
-      // Removes delProperty from xml.
-      cp_partial_doc = cp_partial_doc.replace(match[0], "")
-    }
-  }
-  catch (e) {
-    console.warn(`Trouble parsing delete: ${e}`);
-  }
-  return cp_partial_doc;
-}
-
-/**
- * Function that scrapes the incoming xml for messages and prints to console if
- * debugging is enabled.
- * @param {XMLDocument} partial_doc XML text from INDI.
- * @returns {XMLDocument} Copy of the partial document put in.
- */
-const scrapeMessages = (partial_doc) => {
-  try {
-    var cp_partial_doc = partial_doc;
-
-    while ((match = XmlRegex.XML_MESSAGE.exec(partial_doc))) {
-      //TODO: We should check for device here.
-      // Parse match
-      const parser = new DOMParser();
-      var dom = parser.parseFromString(match, "application/xml");
-      var root_node = dom.documentElement; // Root node
-
-      var msg = root_node.getAttribute("message");
-      var device = root_node.getAttribute("device");
-      var timestamp = root_node.getAttribute("timestamp");
-
-      // Log message if enabled.
-      Config.INDI_CONSOLE_DEBUG && console.log(`${timestamp} ${device} ${msg}`);
-      logging.log(msg, timestamp, device);
-
-      // Removes message from xml.
-      cp_partial_doc = cp_partial_doc.replace(match[0], "")
-    }
-  }
-  catch (e) {
-    console.warn(`Trouble parsing message: ${e}`);
-  }
-  return cp_partial_doc;
 }

--- a/pyindi/www/static/js/maps-indi.js
+++ b/pyindi/www/static/js/maps-indi.js
@@ -17,15 +17,15 @@ document.addEventListener("DOMContentLoaded", () => {
   })
 
   console.log(`Accepting ${indi_types}`);
-  
+
   // create web server connection
   wsStart();
 })
 
 /**
  * Creates websocket connection. Responsible for event listeners for websocket.
- * If websocket closes will try again in WS_RETRY millaseconds. Error codes 
- * aren't worried about because we never get information from websocket errors 
+ * If websocket closes will try again in WS_RETRY millaseconds. Error codes
+ * aren't worried about because we never get information from websocket errors
  * due to security risks.
  */
 const wsStart = () => {
@@ -101,14 +101,14 @@ const wsSend = (msg) => {
 }
 
 /**
- * Sets an indi property. The first parameter must indicate the property data 
- * type, which is either Number, Text, Switch, or Light. The second parameter 
- * must indicate the INDI device and property name as a string separated by a 
- * period, e.g.: "Telescope.Position". The remaining parameters must be INDI 
+ * Sets an indi property. The first parameter must indicate the property data
+ * type, which is either Number, Text, Switch, or Light. The second parameter
+ * must indicate the INDI device and property name as a string separated by a
+ * period, e.g.: "Telescope.Position". The remaining parameters must be INDI
  * property element-value pairs.
- * 
+ *
  * The message is only sent if READ_WRITE is true.
- * 
+ *
  * @example
  * setIndi("Number", "Telescope.Position", "RA", "2 31 49", "Dec", "89 15.84");
  * This is sent as:
@@ -152,7 +152,7 @@ const setindi = (...theArgs) => {
     // Send xml
     wsSend(xml);
     msgprefix = "Websocket send: ";
-  } 
+  }
   else {
     alert("All commands are disabled in Read-Only mode");
     msgprefix = "Websocket send (not sent): ";
@@ -165,21 +165,21 @@ const setindi = (...theArgs) => {
 }
 
 /**
- * API function for setting up a callback function when a given INDI property 
- * arrives. Also requests these properties from the indiserver. This only 
- * supports one callback per property per page. Properties are specified as 
+ * API function for setting up a callback function when a given INDI property
+ * arrives. Also requests these properties from the indiserver. This only
+ * supports one callback per property per page. Properties are specified as
  * INDI device and property name separated by a period, e.g.:
- * "Telescope.Position". If property name is '*', eg 'Telescope.*', then ALL 
- * properties with the given device will be called. Property callbacks must be 
- * a javascript function that takes the property mapped as a javascript object 
+ * "Telescope.Position". If property name is '*', eg 'Telescope.*', then ALL
+ * properties with the given device will be called. Property callbacks must be
+ * a javascript function that takes the property mapped as a javascript object
  * parameter.
  * @param {String} property Property name.
  * @param {Function} callback Function to apply on property.
- * @param {Boolean} init If false, sends get property and get blob. 
+ * @param {Boolean} init If false, sends get property and get blob.
  */
 const setPropertyCallback = (property, callback, init=false) => {
   setPropertyCallbacks[property] = callback;
-  
+
   // Request this property
   var devname = property.split(".");
   var device = devname[0];
@@ -219,10 +219,10 @@ const setPropertyCallback = (property, callback, init=false) => {
 };
 
 /**
- * Flattens an INDI property's XML element into a javascript object. This 
- * copies the flattenIndi function but uses a nesting approach (less 
+ * Flattens an INDI property's XML element into a javascript object. This
+ * copies the flattenIndi function but uses a nesting approach (less
  * flattened). Note that step, min, max attributes and the value for Properties
- *  of type Number are converted to numeric type, all others are string type. 
+ *  of type Number are converted to numeric type, all others are string type.
  * Also, BLOBs are already unpacked from base64.
  * @param {XMLDocument} xml The parsed xml.
  * @returns {Object} Contains all information from INDI property.
@@ -240,14 +240,14 @@ function flattenIndiLess(xml) {
 
   if (xml.nodeName.includes("Number")) {
     isnum = true;
-    indi.metainfo = "nvp"; 
+    indi.metainfo = "nvp";
   }
   else if (xml.nodeName.includes("Blob")) {
     isblob = true;
     indi.metainfo = "bvp";
   }
   else if (xml.nodeName.includes("Text")) {
-    indi.metainfo = "tvp";	
+    indi.metainfo = "tvp";
   }
   else if (xml.nodeName.includes("Light")) {
     indi.metainfo = "lvp";
@@ -262,13 +262,13 @@ function flattenIndiLess(xml) {
   // Build indi
   for (var i = 0; i < xml.attributes.length; i++) {
     var attr = xml.attributes[i];
-    indi[attr.name] = attr.value;	
+    indi[attr.name] = attr.value;
   }
 
 	children = []
 	var i = 0;
   var child_nodes = xml.children;
-  for (var j=0; j<child_nodes.length; j++) 
+  for (var j=0; j<child_nodes.length; j++)
   {
     var child = child_nodes[j];
     var name = child.getAttribute("name");
@@ -299,7 +299,7 @@ function flattenIndiLess(xml) {
         }
         else if (isblob) {
           // Clean base64
-          indi[name] = window.atob(val.replace (/[^A-Za-z0-9+/=]/g, "")); 
+          indi[name] = window.atob(val.replace (/[^A-Za-z0-9+/=]/g, ""));
         }
         else {
           indi[name] = val.trim();
@@ -318,7 +318,7 @@ function flattenIndiLess(xml) {
 }
 
 /**
- * Function which fires callbacks interested in the given received INDI 
+ * Function which fires callbacks interested in the given received INDI
  * messages. The given text can be a fragment or contain more than one complete
  * document.
  * @param {String} xml_text XML text from INDI
@@ -328,7 +328,7 @@ const updateProperties = (xml_text) => {
     return;
   }
   // Append next chunk
-  partial_doc += xml_text; 
+  partial_doc += xml_text;
 
   // Process any/all complete INDI messages in partial_doc
   while (true) {
@@ -343,7 +343,7 @@ const updateProperties = (xml_text) => {
 
     // Find next matching closing tag, done if none
     // [0] is the matched string
-    var end_xml_str = `${start_match[0].replace("<", "</")}>`; 
+    var end_xml_str = `${start_match[0].replace("<", "</")}>`;
     var end_idx = partial_doc.indexOf(end_xml_str, start_match.index);
     if (end_idx < 0) {
       return;
@@ -352,9 +352,9 @@ const updateProperties = (xml_text) => {
 
     // Extract property xml and remove from partial_doc
     var xml_doc = partial_doc.substring(start_match.index, end_after_idx);
-			
+
     partial_doc = partial_doc.substring(end_after_idx);
-    
+
     try {
       const parser = new DOMParser();
       var dom = parser.parseFromString(xml_doc, "application/xml");
@@ -374,7 +374,7 @@ const updateProperties = (xml_text) => {
       // Gets function from handleProperty callback in client.html
       // If property doesn't exist specified then use general
       var callback = setPropertyCallbacks[`${device}.${name}`] || setPropertyCallbacks[`${device}.*`] || setPropertyCallbacks['*.*'];
-    
+
       if (callback) {
         var indi = flattenIndiLess(root_node);
         callback(indi);
@@ -409,7 +409,7 @@ const scrapeMessages = (partial_doc) => {
       var msg = root_node.getAttribute("message");
       var device = root_node.getAttribute("device");
       var timestamp = root_node.getAttribute("timestamp");
-      
+
       // Log message if enabled.
       Config.INDI_CONSOLE_DEBUG && console.log(`${timestamp} ${device} ${msg}`);
       logging.log(msg, timestamp, device);

--- a/pyindi/www/static/js/updater-indi.js
+++ b/pyindi/www/static/js/updater-indi.js
@@ -4,7 +4,7 @@
  * element with new data.
  * @namespace
  */
- const updater = {
+const updater = {
 	available: {},
 
 	/**
@@ -296,24 +296,28 @@
 		return vector;
 	},
 	/**
-	 * Handles the delProperty tag. 
+	 * Handles the delProperty tag.
 	 * @param {String} device name of indi device.
 	 * @param {String} name name of indi property.
 	 *
 	 */
 	delete(indi) {
 		var selector;
-        if (builder.customGui) {
-          var deviceSelector = `[data-custom-device="${device}"]`;
+    if (builder.customGui) {
+      var deviceSelector = `[data-custom-device="${device}"]`;
  		  var vectorSelector = `[data-custom-vector="${name}"]`;
  		  selector = `${deviceSelector}${vectorSelector}`;
  		}
+    // Select using ID
  		else {
  		  selector = `#${generateId.vector(indi)}`;
 		}
 
-		var ele = document.querySelector(`${selector}`);
-		if(ele)
-			ele.classList.add('pyindi-deleted');
-	}
+		var vector = document.querySelector(`${selector}`);
+		if (vector) {
+			vector.classList.add('pyindi-deleted');
+	  }
+
+    return vector;
+  }
 };

--- a/pyindi/www/static/js/updater-indi.js
+++ b/pyindi/www/static/js/updater-indi.js
@@ -9,7 +9,7 @@
 
 	/**
 	 * Updates what indi properties are available or to be omitted.
-	 * @param {Object} indi Contains all information about INDI property. 
+	 * @param {Object} indi Contains all information about INDI property.
 	 * @param {Boolean=} omit If true, add flag to omit this property.
 	 */
 	setAvailable(indi, omit = false) {
@@ -62,10 +62,10 @@
 		// If vpselector is empty, build
 		if (!document.querySelector(`#${groupSelector}`)) {
 			console.debug(`Creating new group=${indi.device}-${indi.group}`);
-	
+
 			// Doesn't exists, build and add attributes and classes
 			var html = builder.group(indi);
-	
+
 			if (appendTo != null) {
 				appendTo.appendChild(html);
 			}
@@ -75,7 +75,7 @@
 				document.querySelector(`#${parentSelector}`).appendChild(html);
 			}
 		}
-		
+
 		return document.getElementById(groupSelector);
 	},
 
@@ -86,7 +86,7 @@
 	handle(indi) {
     var device = this.device(indi);
     var group = this.group(indi);
-    
+
 		this.setAvailable(indi);
 		return;
 	},
@@ -130,25 +130,25 @@
 	 * @returns {HTMLElement} The element that was updated.
 	 */
 	texts(indi, appendTo = null) {
-		var vectorSelector = generateId.vector(indi);	
+		var vectorSelector = generateId.vector(indi);
 		builder.handle(vectorSelector, indi, appendTo);
-		
+
 		// Update values from indi
 		indi.values.forEach((property) => {
 			var propertySelector = generateId.property(indi, property);
 			var parent = document.querySelector(`#${propertySelector}`);
 			var ro = document.querySelector(`#${propertySelector} .pyindi-ro`);
-	
+
 			// Handle case if wo only, then ro will not exist
 			if (ro) {
 				// Handle null content
 				ro.textContent = utilities.isNull(property.value) ? "" : property.value
 			}
 		})
-	
+
 		// Update LED color on indistate
 		this.led(indi);
-	
+
 		return document.getElementById(vectorSelector);
 	},
 
@@ -161,25 +161,25 @@
 	numbers(indi, appendTo = null) {
 		var vectorSelector = generateId.vector(indi);
 		builder.handle(vectorSelector, indi, appendTo);
-		
+
 		// Update values from indi
 		indi.values.forEach((property) => {
 			var propertySelector = generateId.property(indi, property);
 			var parent = document.querySelector(`#${propertySelector}`);
 			var ro = document.querySelector(`#${propertySelector} .pyindi-ro`);
-	
+
 			// Handle case if wo only, then ro will not exist
 			if (ro) {
 				var format = parent.getAttribute("data-format");
 				var value = utilities.formatNumber(property.value, format);
-	
+
 				ro.textContent = value;
 			}
 		})
-	
+
 		// Update LED color on indistate
 		this.led(indi);
-	
+
 		return document.getElementById(vectorSelector)
 	},
 
@@ -222,22 +222,22 @@
 	lights(indi, appendTo = null) {
 		var vectorSelector = generateId.vector(indi);
 		builder.handle(vectorSelector, indi, appendTo);
-		
+
 		// Update values from indi
 		indi.values.forEach((property) => {
 			var propertySelector = generateId.property(indi, property);
 			var light = document.querySelector(`#${propertySelector}`);
-	
+
 			// Update the color of the light depending on indistate
 			var colors = converter.indiToCss(property.value);
 			light.style.backgroundColor = colors["background-color"]
 			light.style.color = colors["color"]
-	
+
 			// Assign class for blinking if enabled
 			if (Config.BLINKING_BUSY_ALERT_LIGHTS) {
 				let blink = converter.indiToBlink(property.value);
 				if (!blink) {
-					// No blink so remove 
+					// No blink so remove
 					light.classList.remove("blinking-busy", "blinking-alert")
 				}
 				else if (blink === "blinking-busy") {
@@ -250,10 +250,10 @@
 				}
 			}
 		});
-	
+
 		// Update LED color on indistate
 		this.led(indi);
-	
+
 		return document.getElementById(vectorSelector);
 	},
 
@@ -279,7 +279,7 @@
 		var deviceSelector = `[data-custom-device="${indi.device}"]`;
 		var vectorSelector = `[data-custom-vector="${indi.name}"]`;
 
-		var appendToSelector = `${deviceSelector}${vectorSelector}`; 
+		var appendToSelector = `${deviceSelector}${vectorSelector}`;
 		var appendTo = document.querySelector(`${appendToSelector}`);
 
 		// If it doesn't exist, return undefined.
@@ -295,59 +295,4 @@
 
 		return vector;
 	}
-};
-
-/**
- * Contains methods to convert from a state to another.
- * @namespace
- */
-const converter = {
-	/**
-	 * Converts INDI state to a CSS color styling.
-	 * @param {String} indiState The current INDI state.
-	 * @returns {Object} Styling to apply. 
-	 */
-	indiToCss(indiState) {
-		var state = IndiStates["Unknown"] // Default return.
-		if (IndiStates.hasOwnProperty(indiState)) {
-			state = IndiStates[indiState];
-		}
-		else {
-			console.warn(`${indiState} is not valid INDI state, should be ${Object.keys(IndiStates)}`);
-		}
-		
-		return state
-	},
-
-	/**
-	 * Converts INDI state to blinking state for emergency.
-	 * @param {Object} indiState The current INDI state.
-	 * @returns {String} The styling to apply.
-	 */
-	indiToBlink(indiState) {
-		var blink = null;
-		if (IndiBlinks.hasOwnProperty(indiState)) {
-			blink = IndiBlinks[indiState];
-		}
-
-		return blink
-	},
-
-	/**
-	 * Converts switch to html element.
-	 * @param {String} indiRule INDI rule to apply to switch.
-	 * @returns {String} String describing the switch type, radio or checkbox.
-	 */
-	indiSwitchToSelector(indiRule) {
-		var sw = "radio"; // Default return
-
-		if (IndiSwitchRules.hasOwnProperty(indiRule)) {
-			sw = IndiSwitchRules[indiRule];
-		}
-		else {
-			console.warn(`${indiRule} is not valid INDI rule, should be ${Object.keys(IndiSwitchRules)}`);
-		}
-
-		return sw
-	},
 };

--- a/pyindi/www/static/js/utils-indi.js
+++ b/pyindi/www/static/js/utils-indi.js
@@ -66,7 +66,7 @@ const utilities = {
 	noSpaces(str) {
 		return str.replace(/ /g, '_');
 	},
-	
+
 	/**
 	 * Swaps spaces with "_" and removes special charactors.
 	 * @param {String} str The string to remove special characters and spaces.
@@ -123,3 +123,58 @@ const utilities = {
 	}
 };
 
+
+/**
+ * Contains methods to convert from a state to another.
+ * @namespace
+ */
+ const converter = {
+	/**
+	 * Converts INDI state to a CSS color styling.
+	 * @param {String} indiState The current INDI state.
+	 * @returns {Object} Styling to apply.
+	 */
+	indiToCss(indiState) {
+		var state = IndiStates["Unknown"] // Default return.
+		if (IndiStates.hasOwnProperty(indiState)) {
+			state = IndiStates[indiState];
+		}
+		else {
+			console.warn(`${indiState} is not valid INDI state, should be ${Object.keys(IndiStates)}`);
+		}
+
+		return state
+	},
+
+	/**
+	 * Converts INDI state to blinking state for emergency.
+	 * @param {Object} indiState The current INDI state.
+	 * @returns {String} The styling to apply.
+	 */
+	indiToBlink(indiState) {
+		var blink = null;
+		if (IndiBlinks.hasOwnProperty(indiState)) {
+			blink = IndiBlinks[indiState];
+		}
+
+		return blink
+	},
+
+	/**
+	 * Converts switch to html element.
+	 * @param {String} indiRule INDI rule to apply to switch.
+	 * @returns {String} String describing the switch type, radio or checkbox.
+	 */
+	indiSwitchToSelector(indiRule) {
+		var sw = "radio"; // Default return
+
+		if (IndiSwitchRules.hasOwnProperty(indiRule)) {
+			sw = IndiSwitchRules[indiRule];
+		}
+		else {
+			console.warn(`${indiRule} is not valid INDI rule, should be ${Object.keys(IndiSwitchRules)}`);
+		}
+
+		return sw
+	},
+};

--- a/pyindi/www/templates/index.html
+++ b/pyindi/www/templates/index.html
@@ -14,21 +14,34 @@
 			}
 
 			/**
-			* This function will be called whenever an INDI property with the device 
+			* This function will be called whenever an INDI property with the device
 			*	{{ devices }} is received. This is where users should modify the
 			*	code to append to specific objects.
 			*
-			*	If wanting to use a custom GUI, enable in the configuration and provide the correct syntax for selecting 
+			*	If wanting to use a custom GUI, enable in the configuration and provide the correct syntax for selecting
 			* elements.
 			* @param {Object} indi Contains all information about INDI property
 			*/
 			const handleProperty = (indi) => {
-				if (indi.op === IndiOp.DEFINITION) {
-					updater.handle(indi);
-					// Handle vector for the first time here
-				}
-				// Handle vector every time it comes in
-				var vector = updater.vector(indi);
+        let htmlElement = handle(indi);
+
+        // Bad selector, meaning the custom GUI selector not found
+        if (!htmlElement) {
+          return;
+        }
+
+        if (indi.op === IndiOp.DEFINITION) {
+          // Only update once (on definition)
+          // Use for adding tooltips or modifying the look once
+        }
+        else if (indi.op === IndiOp.SET) {
+          // Update everytime new values come in
+          // Use for updating labels with values
+        }
+        else {
+          console.warn(`Indi definition: ${indi.op} not found`)
+        }
+
         return;
 			}
 		</script>

--- a/pyindi/www/templates/index.html
+++ b/pyindi/www/templates/index.html
@@ -26,7 +26,12 @@
         let htmlElement = handle(indi);
 
         // Bad selector, meaning the custom GUI selector not found
+        // Want to check if not delProperty, message, or BLOB before issuing tip
         if (!htmlElement) {
+          if (ApprovedOp.includes(indi.op) && indi.metainfo !== "bvp") {
+            tag_str = `<div data-custom-vector="${indi.name}" data-custom-device="${indi.device}"/>`;
+            console.debug(`Selector not found. To add vector to page use ${tag_str}`);
+          }
           return;
         }
 


### PR DESCRIPTION
The reasons for these changes are to:
1. Make it easier for users to use the custom gui option. 

I wanted to move away from users using `updater` and `builder` objects in their code. They still can, however a generic entry point simplifies things.

For users using this code, it would require a change in `handleProperty` function. Where instead of calling `updater` users us `handle`. Take a look at the `gui.html` code for an example. 

The `handle` function in `indi.js` is easy to make modifications on how to process different incoming xml vectors or property changes such as delProperty. 

2. Reduce the need to parse through the xml payload multiple times for grabbing message and delProperty text. 

I believe this simplifies the process of handling incoming xml by using regex groups to determine if message or delProperty. 





Note: My whitespace remover went a little crazy on a couple files.
