### PR TITLE
A couple minor updates & improvements

### DIFF
--- a/pyindi/device.py
+++ b/pyindi/device.py
@@ -324,7 +324,7 @@ class IVectorProperty(ABC):
             if hasattr(self, attribute.name):
                 ele.set(attribute.name, str(getattr(self, attribute.name)))
         for prop in self.iprops:
-            logging.warning(prop)
+            logging.debug(prop)
             ele.append(prop.Set())
 
         if msg is not None:

--- a/pyindi/device.py
+++ b/pyindi/device.py
@@ -1183,11 +1183,11 @@ class device(ABC):
         elif timestamp is None:
             timestamp = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
 
-        xml = f'<message message="[{msgtype}] {msg}" '
-        xml += f'timestamp="{timestamp}" '
-        xml += f'device="{self.name()}"/> '
-
-        self.outq.put_nowait(xml.encode())
+        xml = etree.Element("message",
+                            attrib={"message": f"[{msgtype}] {msg}",
+                                    "timestamp": timestamp,
+                                    "device": self.name()})
+        self.outq.put_nowait(etree.tostring(xml))
         # self.writer.write(xml.encode())
 
     def IDSetNumber(self, n: INumberVector, msg=None):

--- a/pyindi/device.py
+++ b/pyindi/device.py
@@ -855,7 +855,8 @@ class device(ABC):
         astart
         """
 
-        self.mainloop = asyncio.get_event_loop()
+        if self.mainloop is None:
+            self.mainloop = asyncio.get_event_loop()
         self.reader, self.writer = self.mainloop.run_until_complete(stdio())
         self.running = True
         future = asyncio.gather(
@@ -874,7 +875,8 @@ class device(ABC):
         other device tasks.
         """
 
-        self.mainloop = asyncio.get_running_loop()
+        if self.mainloop is None:
+            self.mainloop = asyncio.get_event_loop()
         self.reader, self.writer = await stdio()
         self.running = True
         future = asyncio.gather(

--- a/pyindi/device.py
+++ b/pyindi/device.py
@@ -282,9 +282,8 @@ class IVectorProperty(ABC):
         tagname = "def" + self.tagcontext
         dtd_elements = {tag.name: tag for tag in self.dtd.iterelements()}
         if tagname not in dtd_elements:
-            raise AttributeError(
-                "{tagname} not defined in \
-                                 Document Type Definition")
+            raise AttributeError(f"{tagname} not defined in Document Type "
+                                 "Definition")
 
         ele_definition = dtd_elements[tagname]
         ele = etree.Element(ele_definition.name)
@@ -316,9 +315,8 @@ class IVectorProperty(ABC):
         tagname = "set" + self.tagcontext
         dtd_elements = {tag.name: tag for tag in self.dtd.iterelements()}
         if tagname not in dtd_elements:
-            raise AttributeError(
-                f"{tagname} not defined in \
-                                 Document Type Definition")
+            raise AttributeError(f"{tagname} not defined in Document Type "
+                                 "Definition")
 
         ele_definition = dtd_elements[tagname]
         ele = etree.Element(ele_definition.name)
@@ -394,9 +392,8 @@ class IProperty:
         dtd_elements = {tag.name: tag for tag in self.dtd.iterelements()}
 
         if tagname not in dtd_elements:
-            raise AttributeError(
-                f"{tagname} not defined in \
-                                 Document Type Definition")
+            raise AttributeError(f"{tagname} not defined in Document Type "
+                                 "Definition")
 
         ele_definition = dtd_elements[tagname]
         ele = etree.Element(ele_definition.name)
@@ -415,9 +412,8 @@ class IProperty:
         dtd_elements = {tag.name: tag for tag in self.dtd.iterelements()}
 
         if tagname not in dtd_elements:
-            raise AttributeError(
-                f"{tagname} not defined in \
-                                 Document Type Definition")
+            raise AttributeError(f"{tagname} not defined in Document Type "
+                                 "Definition")
 
         ele_definition = dtd_elements[tagname]
         ele = etree.Element(ele_definition.name)
@@ -442,10 +438,8 @@ class IProperty:
         elif isinstance(self, IBLOB):
             return self.data
 
-        raise TypeError(f"""value method must be called with INumber,
-        IText, ILight, ISwitch or IBLOB not {type(self)}
-        {isinstance(self, INumber)}
-        """)
+        raise TypeError(f"value method must be called with INumber, IText,"
+                        f" ILight, ISwitch or IBLOB not {type(self)}")
 
     @value.setter
     def value(self, val):
@@ -462,14 +456,8 @@ class IProperty:
         elif isinstance(self, IBLOB):
             self.data = val
         else:
-            raise TypeError(f"""
-        value method must be called with INumber, IText,
-        ILight, ISwitch or IBLOB not {type(self)} {self}
-        {isinstance(self, INumber)} {self.tagcontext}
-        {type(self) == INumber}
-        {self.tagcontext == "Switch"}
-        {self.__class__ == ISwitch}
-        """)
+            raise TypeError("value method must be called with INumber, IText,"
+                            f" ILight, ISwitch or IBLOB, not {type(self)}")
 
 
 class INumberVector(IVectorProperty):
@@ -898,12 +886,9 @@ class device(ABC):
                     func(self)
 
             except Exception as error:
-                sys.stderr.write(
-                    f"There was an exception in the \
-                    later decorated fxn {func}:")
-
-                sys.stderr.write(f"{error}")
-                sys.stderr.write("See traceback below.")
+                sys.stderr.write("There was an exception in the later "
+                                 f"decorated fxn {func}:\n{error}\nSee "
+                                 "traceback below.")
                 traceback.print_exc(file=sys.stderr)
 
     def exception(self, loop, context):
@@ -1117,16 +1102,15 @@ class device(ABC):
             try:
                 ivec = self.vectorFactory(xml_def.tag, xml_def.attrib, properties)
             except Exception as error:
-                logging.error(f"The following error was caused by this xml tag \
-                        \n {etree.tostring(xml_def)}")
+                logging.error("The following error was caused by this xml tag:"
+                              f"\n{etree.tostring(xml_def).decode()}")
                 logging.error(error)
                 raise
             self.IDDef(ivec)
 
     def ISNewNumber(self, dev: str, name: str, values: list, names: list):
         raise NotImplementedError(
-            "Device driver must \
-                                  overload ISNewNumber method.")
+            "Device driver must overload ISNewNumber method.")
 
     def IUFind(self, name, device=None, group=None):
         """
@@ -1174,9 +1158,8 @@ class device(ABC):
         return vp
 
     def ISGetProperties(self, device):
-        raise NotImplementedError(
-            f"Subclass of {self} must \
-                                  implement ISGetProperties")
+        raise NotImplementedError(f"Subclass of {self} must implement "
+                                  "ISGetProperties")
 
     def IDMessage(
         self, msg: str,
@@ -1372,8 +1355,8 @@ class device(ABC):
                 vec.tp.append(iprop)
 
         else:
-            message = f"vector_type argument must be a string containing \
-            Light, Number, Switch, Text or BLOB not {vector_type}"
-            raise ValueError(message)
+            raise ValueError("vector_type argument must be a string containing"
+                             " Light, Number, Switch, Text or BLOB, not "
+                             f"{vector_type}")
 
         return vec

--- a/pyindi/device.py
+++ b/pyindi/device.py
@@ -69,7 +69,7 @@ def printa(msg: Union[str, bytes]):
     We use the stdio fxn now.
     """
 
-    if type(msg) == bytes:
+    if isinstance(msg, bytes):
         msg = msg.decode()
     sys.stdout.write(msg)
     sys.stdout.flush()
@@ -772,7 +772,7 @@ class IBLOB(IProperty):
 
     @value.setter
     def value(self, val: bytes):
-        if type(val) != bytes:
+        if not isinstance(val, bytes):
             raise ValueError("""IBLOB value must by bytes type""")
 
         self.size = len(val)
@@ -1177,7 +1177,7 @@ class device(ABC):
         msgtype : str, optional
             one of "DEBUG", "INFO", "WARN", by default "INFO"
         """
-        if type(timestamp) == datetime.datetime:
+        if isinstance(timestamp, datetime.datetime):
             timestamp = timestamp.strftime("%Y-%m-%dT%H:%M:%S")
 
         elif timestamp is None:


### PR DESCRIPTION
This PR contains a few miscellaneous fixes/improvements to device.py that I've noticed and made as I've worked with the code. Some of these changes are basically just code cleanup, others have a more concrete impact.

One update of note is that now, the `mainloop` argument is actually used in `.start()` and `.astart()` if it is provided upon instantiation. Previously these methods were reassigning `self.mainloop = asyncio.get_running_loop()` when called, regardless of whether `self.mainloop` already existed.