### PR TITLE
Fix Docker workflow: run only on master push, update checkout to v6

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,11 +1,14 @@
 name: Publish to Docker
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
 jobs:
   build:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[docker skip]')"
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Publish to Registry
       uses: elgohr/Publish-Docker-Github-Action@v5
       with:


### PR DESCRIPTION
## Problem

The Docker publish workflow runs on both `push` and `pull_request` events. GitHub doesn't pass repository secrets to PR workflow runs (security restriction), so the `DOCKER_USERNAME`/`DOCKER_PASSWORD` secrets are always empty on PRs, causing every PR check to fail with:

> Unable to find the username. Did you set with.username?

## Fix

- Scope the trigger to `push` on `master` only — Docker image publishing only makes sense when code lands on the default branch, not on every PR
- Update `actions/checkout` from `v4` to `v6` (supersedes dependabot PR #41, which can be closed)