### PR TITLE
Add `DRIVER_INTERFACE` enum

### DIFF
--- a/pyindi/device.py
+++ b/pyindi/device.py
@@ -217,6 +217,37 @@ class ISState(INDIEnum):
         raise ValueError(f"ISState must be either Off or On not {string}")
 
 
+class DRIVER_INTERFACE(Enum):
+    """Driver interface enum.
+
+    Used by drivers to advertise to clients which interface(s) they implement.
+
+    See https://docs.indilib.org/drivers/basics/driver-interface.html for details.
+    """
+
+    GENERAL_INTERFACE       = 0       # Default interface for all INDI devices
+    TELESCOPE_INTERFACE     = 1 <<  0 # Telescope interface
+    CCD_INTERFACE           = 1 <<  1 # CCD interface
+    GUIDER_INTERFACE        = 1 <<  2 # Guider interface
+    FOCUSER_INTERFACE       = 1 <<  3 # Focuser interface
+    FILTER_INTERFACE        = 1 <<  4 # Filter interface
+    DOME_INTERFACE          = 1 <<  5 # Dome interface
+    GPS_INTERFACE           = 1 <<  6 # GPS interface
+    WEATHER_INTERFACE       = 1 <<  7 # Weather interface,
+    AO_INTERFACE            = 1 <<  8 # Adaptive Optics Interface
+    DUSTCAP_INTERFACE       = 1 <<  9 # Dust Cap Interface
+    LIGHTBOX_INTERFACE      = 1 << 10 # Light Box Interface
+    DETECTOR_INTERFACE      = 1 << 11 # Detector interface
+    ROTATOR_INTERFACE       = 1 << 12 # Rotator interface
+    SPECTROGRAPH_INTERFACE  = 1 << 13 # Spectrograph interface
+    CORRELATOR_INTERFACE    = 1 << 14 # Correlators (interferometers) interface
+    AUX_INTERFACE           = 1 << 15 # Auxiliary interface
+    OUTPUT_INTERFACE        = 1 << 16 # Digital Output (e.g. Relay) interface
+    INPUT_INTERFACE         = 1 << 17 # Digital/Analog Input (e.g. GPIO) interface
+    POWER_INTERFACE         = 1 << 18 # Auxiliary interface
+    SENSOR_INTERFACE        = SPECTROGRAPH_INTERFACE | DETECTOR_INTERFACE | CORRELATOR_INTERFACE
+
+
 class IVectorProperty(ABC):
     """
     INDI Vector asbstractions

--- a/pyindi/device.py
+++ b/pyindi/device.py
@@ -104,7 +104,7 @@ class WinIO:
 class INDIEnumMember(int):
     """
     ## INDIEnumMember
-    This sublcasses the int class to match
+    This subclasses the int class to match
     the standard enum int type but adds
     a string in the assignment to allow
     for comparison with the raw xml

--- a/pyindi/device.py
+++ b/pyindi/device.py
@@ -244,7 +244,7 @@ class DRIVER_INTERFACE(Enum):
     AUX_INTERFACE           = 1 << 15 # Auxiliary interface
     OUTPUT_INTERFACE        = 1 << 16 # Digital Output (e.g. Relay) interface
     INPUT_INTERFACE         = 1 << 17 # Digital/Analog Input (e.g. GPIO) interface
-    POWER_INTERFACE         = 1 << 18 # Auxiliary interface
+    POWER_INTERFACE         = 1 << 18 # Power interface
     SENSOR_INTERFACE        = SPECTROGRAPH_INTERFACE | DETECTOR_INTERFACE | CORRELATOR_INTERFACE
 
 

--- a/pyindi/device.py
+++ b/pyindi/device.py
@@ -59,9 +59,6 @@ async def stdio(limit=asyncio.streams._DEFAULT_LIMIT):
     return reader, writer
 
 
-
-
-
 def printa(msg: Union[str, bytes]):
     """
     This was the old way of writing to stdout


### PR DESCRIPTION
Many clients expect INDI drivers to publish a DRIVER_INFO vector that includes a DRIVER_INTERFACE element. This DRIVER_INTERFACE is a bitwise OR of the values listed on [this page](https://docs.indilib.org/drivers/basics/driver-interface.html), and advertises what kind(s) of device the driver represents.

This PR adds a new enum in device.py that encodes these interface values for convenience.

Note: I'm not quite sure if this is where this should go. I couldn't really think of anywhere better, but if there is a more optimal location for this definition to live, I'd be happy to move it.